### PR TITLE
Ensure our identifier arrays are indexed as we're expecting them to be

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -75,6 +75,8 @@ trait Resource
      */
     private function fetchConcurrentResources(array $ids)
     {
+        // Ensure our array is indexed sequentially
+        $ids = array_values($ids);
         $client = $this->getHttpClient();
 
         $requests = function () use ($client, $ids) {

--- a/src/Work.php
+++ b/src/Work.php
@@ -125,7 +125,6 @@ class Work
         } else {
             $workExampleIds = [];
         }
-        $workExampleIds = isset($subjectData['workExample']) ? $subjectData['workExample'] : [];
         return array_values(array_diff($workExampleIds, array_keys($this->examples)));
     }
 

--- a/src/Work.php
+++ b/src/Work.php
@@ -116,6 +116,15 @@ class Work
     public function getUnresolvedWorkExamples()
     {
         $subjectData = $this->getSubjectData();
+        if (isset($subjectData['workExample'])) {
+            if (is_array($subjectData['workExample'])) {
+                $workExampleIds = $subjectData['workExample'];
+            } else {
+                $workExampleIds = [$subjectData['workExample']];
+            }
+        } else {
+            $workExampleIds = [];
+        }
         $workExampleIds = isset($subjectData['workExample']) ? $subjectData['workExample'] : [];
         return array_values(array_diff($workExampleIds, array_keys($this->examples)));
     }

--- a/src/Work.php
+++ b/src/Work.php
@@ -117,7 +117,7 @@ class Work
     {
         $subjectData = $this->getSubjectData();
         $workExampleIds = isset($subjectData['workExample']) ? $subjectData['workExample'] : [];
-        return array_diff($workExampleIds, array_keys($this->examples));
+        return array_values(array_diff($workExampleIds, array_keys($this->examples)));
     }
 
     /**


### PR DESCRIPTION
`Work->getUnresolvedWorkExamples()` was returning the result of `array_diff()`, so it wasn't necessarily indexed sequentially, which is what `Resource->fetchConcurrentResources()` was expecting.